### PR TITLE
Fix for issue with latest colcon build with setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
     python_requires='>=3',
     packages=find_packages(exclude=['test']),
     data_files=[
+        ('share/ament_index/resource_index/packages', ['resource/' + package_name]),
         ('share/' + package_name + '/resource', ['resource/completion.bash']),
         ('share/' + package_name + '/resource', ['resource/xacro'])
     ],


### PR DESCRIPTION
**Fix for issue with latest colcon build with setup.py**

@AAlon 
Facing issue with xacro package with latest colcon. After building with latest colcon and source setup.bash, not able to locate a package in ros2 pkg list.

Found the root cause as mentioned in [this link](https://answers.ros.org/question/333363/ros2-no-package-found-in-pure-python-package-with-setuppy-with-new-ubuntu-1804dashing) and fixed accordingly.
