### PR TITLE
Modify setup.py of package to install a marker file for ament's index

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,9 @@ setup(
     packages=find_packages(exclude=['test']),
     data_files=[
         ('share/' + package_name + '/resource', ['resource/completion.bash']),
-        ('share/' + package_name + '/resource', ['resource/xacro'])
+        ('share/' + package_name + '/resource', ['resource/xacro']),
+        ('share/' + package_name, ['package.xml']),
+        ('share/ament_index/resource_index/packages', ['resource/' + package_name])
     ],
     install_requires=['setuptools'],
     zip_safe=True,


### PR DESCRIPTION
A recent change in colcon dictates that Python ROS2 packages should install an empty file with the same name as the package into ament's index directory in order to be installable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.